### PR TITLE
Feat: Add threshold support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ function Demo() {
 export default Demo;
 ```
 
+You can also use the `threshold` prop to control how much of the element must be visible before it is considered in view. A value of `0` (default) triggers as soon as any part of the element is visible, while `1` requires the element to be fully visible within the viewport.
+
+```tsx
+<IOScrollView threshold={0.5}>
+  <InView onChange={(inView: boolean) => console.log('Inview:', inView)}>
+    <Text>This triggers when at least 50% of the element is visible.</Text>
+  </InView>
+</IOScrollView>
+```
+
 Please note that the functionality of the InView component is dependent on the use of the withIO higher-order component to wrap your scrollable component. The react-native-intersection-observer library presently offers two frequently used scrollable components: IOScrollView and IOFlatList. It's imperative to utilize the InView component within one of these two components for it to work as intended. If neither IOScrollView nor IOFlatList suits your requirements, you have the flexibility to employ withIO to encapsulate your custom scrollable components.
 
 ```tsx
@@ -92,7 +102,8 @@ Furthermore, InView cannot be used within nested scrollable components. It solel
 
   | Name | Type | Default | Required | Description |
   | --- | --- | --- | --- | --- |
-  | [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin) | { top: number; left: number; right: number; bottom: number } | undefined | false | root margin |
+  | [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin) | { top: number; left: number; right: number; bottom: number } | undefined | false | Expands or shrinks the viewport bounds used for intersection detection. |
+  | [threshold](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds) | number | 0 | false | A value between 0 and 1 indicating what fraction of the element must be visible before it is considered in view. |
 
 - Methods: Inherits [ScrollView Methods](https://reactnative.dev/docs/scrollview#methods)
 
@@ -102,7 +113,8 @@ Furthermore, InView cannot be used within nested scrollable components. It solel
 
   | Name | Type | Default | Required | Description |
   | --- | --- | --- | --- | --- |
-  | [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin) | { top: number; left: number; right: number; bottom: number } | undefined | false | root margin |
+  | [rootMargin](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin) | { top: number; left: number; right: number; bottom: number } | undefined | false | Expands or shrinks the viewport bounds used for intersection detection. |
+  | [threshold](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds) | number | 0 | false | A value between 0 and 1 indicating what fraction of the element must be visible before it is considered in view. |
 
 - Methods: Inherits [FlatList Methods](https://reactnative.dev/docs/flatlist#methods)
 

--- a/lib/IntersectionObserver.d.ts
+++ b/lib/IntersectionObserver.d.ts
@@ -25,6 +25,7 @@ export interface RootMargin {
 export interface IntersectionObserverOptions {
     root: Root;
     rootMargin?: RootMargin;
+    threshold?: number
 }
 export type IntersectionObserverCallback = (entries: IntersectionObserverEntry[]) => void;
 export declare const defaultRootMargin: RootMargin;

--- a/lib/IntersectionObserver.js
+++ b/lib/IntersectionObserver.js
@@ -5,6 +5,7 @@ export const defaultRootMargin = {
     top: 0,
     bottom: 0,
 };
+export const defaultThreshold = 0;
 class IntersectionObserver {
     callback;
     options;
@@ -37,6 +38,7 @@ class IntersectionObserver {
     }, 300, { leading: false, trailing: true });
     handleScroll = throttle(() => {
         const rootMargin = this.options?.rootMargin || defaultRootMargin;
+        const threshold = Math.min(Math.max(this.options?.threshold ?? defaultThreshold, 0), 1);
         const { horizontal, current: { contentOffset, contentSize, layoutMeasurement, }, } = this.options.root;
         if (contentSize.width <= 0 ||
             contentSize.height <= 0 ||
@@ -60,16 +62,15 @@ class IntersectionObserver {
             if (horizontal) {
                 isIntersecting =
                     contentOffsetWithLayout + (rootMargin.right || 0) >=
-                        targetLayout.x &&
-                        contentOffset.x - (rootMargin.left || 0) <=
-                            targetLayout.x + targetLayout.width;
-            }
-            else {
+                        targetLayout.x + (targetLayout.width * threshold) &&
+                    contentOffset.x - (rootMargin.left || 0) <=
+                        targetLayout.x + targetLayout.width - (targetLayout.width * threshold);
+            } else {
                 isIntersecting =
                     contentOffsetWithLayout + (rootMargin.bottom || 0) >=
-                        targetLayout.y &&
-                        contentOffset.y - (rootMargin.top || 0) <=
-                            targetLayout.y + targetLayout.height;
+                        targetLayout.y + (targetLayout.height * threshold) &&
+                    contentOffset.y - (rootMargin.top || 0) <=
+                        targetLayout.y + targetLayout.height - (targetLayout.height * threshold);
             }
             if (target.inView !== isIntersecting) {
                 target.inView = isIntersecting;

--- a/lib/withIO.d.ts
+++ b/lib/withIO.d.ts
@@ -3,6 +3,7 @@ import { ScrollView } from 'react-native';
 import { RootMargin } from './IntersectionObserver';
 export interface IOComponentProps {
     rootMargin?: RootMargin;
+    threshold?: number
 }
 declare function withIO<CompProps extends Pick<ComponentProps<typeof ScrollView>, 'horizontal' | 'scrollEventThrottle' | 'onContentSizeChange' | 'onLayout' | 'onScroll'>>(Comp: new (props: CompProps) => any, methods: string[]): new (props: CompProps) => any;
 export default withIO;

--- a/lib/withIO.js
+++ b/lib/withIO.js
@@ -46,6 +46,9 @@ function withIO(Comp, methods) {
                 get rootMargin() {
                     return self.props.rootMargin;
                 },
+                get threshold() {
+                    return self.props.threshold;
+                }
             });
             this.manager = manager;
             this.contextValue = {


### PR DESCRIPTION
This PR adds support for a threshold prop on IOScrollView and IOFlatList, 
[Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds).

What changed:

- Added threshold option to IntersectionObserver — Number between 0 and 1 indicating the percentage that should be visible before triggering. 
- Default value is 0 
- Updated intersection logic in IntersectionObserver.js to apply the threshold for both horizontal and vertical scroll
- Added threshold prop to withIO
- Updated README with documentation and a usage example

Tested with threshold set to 0.5
<table>
  <tr style="background-color: #F2F2F2;">
    <th>IOScrollView Example</th>
    <th>IOFlatList Vertical Example</th>
    <th>IOFlatList Horizontal Example</th>
    <th>WithIO Example</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/3b5b9ec0-f3d9-41a9-b8a1-faac829c8232"/></td>
     <td><video src="https://github.com/user-attachments/assets/34ce3796-438d-44e9-9c3b-147e5038cc1b"/></td>
     <td><video src="https://github.com/user-attachments/assets/c1460a18-5739-4ed1-b3a6-d64b671925e2"/></td>
    <td><video src="https://github.com/user-attachments/assets/00056f3a-f258-4631-94f1-7b6dfa9fd990"/></td>
  </tr>
</table>


Patch file if needed: https://gist.github.com/nk711/8c0450a107d8382a759360643ec454b7